### PR TITLE
Improve theme color contrast with semantic tokens

### DIFF
--- a/design.md
+++ b/design.md
@@ -97,17 +97,20 @@ ColaMD 是轻量 Markdown 编辑器，不追求功能堆叠。每增加一个按
 | --- | --- |
 | 背景 | `--bg-color` |
 | 正文 | `--text-color` |
-| 次要文字 / 图标 | `--text-muted` |
+| 次要文字 | `--text-secondary` |
+| 弱化图标 / 禁用状态 | `--text-muted` |
 | 边框 | `--border-color` |
 | 链接 / 选中 | `--link-color` |
 | 代码背景 | `--code-bg` / `--code-block-bg` |
+| 搜索匹配 | `--search-match-bg` / `--search-match-current-bg` |
 
 约定：
 
 - 默认控件背景为透明。
 - hover 使用低透明度的中性色背景，不制造新的色块。
 - active 状态可以使用主题强调色，但必须克制。
-- 次要图标使用 `--text-muted`，不要使用纯黑或纯白。
+- 次要文字使用 `--text-secondary`，与主题背景至少保持 WCAG AA 对比度。
+- 次要图标使用 `--text-muted`，不要借给需要阅读的文字。
 - tooltip 使用主题背景、边框和轻微阴影，不使用高饱和气泡。
 
 ## 5. 尺寸与动效

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "scripts": {
     "dev": "electron-vite dev",
     "build": "electron-vite build",
+    "check:theme-colors": "node scripts/check-theme-colors.mjs",
     "preview": "electron-vite preview",
     "dist": "electron-vite build && electron-builder",
     "dist:mac": "electron-vite build && electron-builder --mac",

--- a/scripts/check-theme-colors.mjs
+++ b/scripts/check-theme-colors.mjs
@@ -1,0 +1,166 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const dir_project = process.cwd()
+const path_base = path.join(dir_project, 'src/renderer/themes/base.css')
+const path_premium = path.join(dir_project, 'src/renderer/themes/premium.css')
+const dir_themes = path.join(dir_project, 'themes')
+
+const text_base = fs.readFileSync(path_base, 'utf8')
+const text_built_in = [
+	text_base,
+	fs.readFileSync(path_premium, 'utf8')
+].join('\n')
+
+const values_secondary = {
+	light: '#656d76',
+	dark: '#aab3bd',
+	elegant: '#6c6c6c',
+	sepia: '#7b6b54',
+	notion: '#777674',
+	bear: '#767676',
+	writer: '#757571',
+	'solarized-dark': '#a4bbc3',
+	nord: '#aebdd4',
+	gruvbox: '#c5b5a5',
+	dracula: '#afb7db',
+	midnight: '#b1b1b1'
+}
+
+const values_link = {
+	elegant: '#bc4424',
+	sepia: '#9c5e29',
+	'solarized-dark': '#3093da'
+}
+
+function getVariables(text_block) {
+	const values_token = {}
+	const pattern_token = /--([a-z-]+):\s*([^;]+);/g
+
+	for (const match_token of text_block.matchAll(pattern_token)) {
+		values_token[match_token[1]] = match_token[2].trim().toLowerCase()
+	}
+
+	return values_token
+}
+
+function getBuiltInTheme(name_theme) {
+	const pattern_theme = new RegExp(
+		`body(?:,\\s*body)?\\.theme-${name_theme}\\s*\\{([^}]+)\\}`
+	)
+	const match_theme = text_built_in.match(pattern_theme)
+	assert.ok(match_theme, `Missing built-in theme: ${name_theme}`)
+	return getVariables(match_theme[1])
+}
+
+function getStandaloneTheme(name_theme) {
+	const path_theme = path.join(dir_themes, `${name_theme}.css`)
+	const text_theme = fs.readFileSync(path_theme, 'utf8')
+	const match_root = text_theme.match(/:root\s*\{([^}]+)\}/)
+	assert.ok(match_root, `Missing :root block: ${name_theme}.css`)
+	return getVariables(match_root[1])
+}
+
+function getRelativeLuminance(value_hex) {
+	const values_rgb = value_hex.slice(1).match(/.{2}/g)
+	assert.ok(values_rgb, `Invalid hex color: ${value_hex}`)
+	const values_linear = values_rgb.map((value_channel) => {
+		const value_srgb = Number.parseInt(value_channel, 16) / 255
+		return value_srgb <= 0.04045
+			? value_srgb / 12.92
+			: ((value_srgb + 0.055) / 1.055) ** 2.4
+	})
+
+	return 0.2126 * values_linear[0]
+		+ 0.7152 * values_linear[1]
+		+ 0.0722 * values_linear[2]
+}
+
+function blendColors(value_foreground, value_background, opacity_foreground) {
+	const values_foreground = value_foreground.slice(1).match(/.{2}/g)
+	const values_background = value_background.slice(1).match(/.{2}/g)
+	assert.ok(values_foreground, `Invalid hex color: ${value_foreground}`)
+	assert.ok(values_background, `Invalid hex color: ${value_background}`)
+	const values_blended = values_foreground.map((value_channel, index_channel) => {
+		const channel_foreground = Number.parseInt(value_channel, 16)
+		const channel_background = Number.parseInt(values_background[index_channel], 16)
+		return Math.round(
+			channel_foreground * opacity_foreground
+			+ channel_background * (1 - opacity_foreground)
+		)
+	})
+
+	return `#${values_blended
+		.map((value_channel) => value_channel.toString(16).padStart(2, '0'))
+		.join('')}`
+}
+
+function getContrastRatio(value_foreground, value_background) {
+	const luminance_foreground = getRelativeLuminance(value_foreground)
+	const luminance_background = getRelativeLuminance(value_background)
+	const luminance_light = Math.max(luminance_foreground, luminance_background)
+	const luminance_dark = Math.min(luminance_foreground, luminance_background)
+	return (luminance_light + 0.05) / (luminance_dark + 0.05)
+}
+
+for (const [name_theme, value_secondary] of Object.entries(values_secondary)) {
+	const values_built_in = getBuiltInTheme(name_theme)
+	const values_standalone = getStandaloneTheme(name_theme)
+
+	assert.equal(values_built_in['text-secondary'], value_secondary)
+	assert.equal(values_standalone['text-secondary'], value_secondary)
+	assert.ok(
+		getContrastRatio(value_secondary, values_built_in['bg-color']) >= 4.5,
+		`${name_theme} secondary text must meet WCAG AA`
+	)
+
+	for (const opacity_match of [0.18, 0.32]) {
+		const value_match = blendColors(
+			values_built_in['link-color'],
+			values_built_in['bg-color'],
+			opacity_match
+		)
+		assert.ok(
+			getContrastRatio(values_built_in['text-color'], value_match) >= 4.5,
+			`${name_theme} search match at ${opacity_match} must meet WCAG AA`
+		)
+	}
+}
+
+for (const [name_theme, value_link] of Object.entries(values_link)) {
+	const values_built_in = getBuiltInTheme(name_theme)
+	const values_standalone = getStandaloneTheme(name_theme)
+
+	assert.equal(values_built_in['link-color'], value_link)
+	assert.equal(values_standalone['link-color'], value_link)
+	assert.ok(
+		getContrastRatio(value_link, values_built_in['bg-color']) >= 4.5,
+		`${name_theme} link must meet WCAG AA`
+	)
+}
+
+const values_solarized = getBuiltInTheme('solarized-dark')
+assert.equal(values_solarized['text-color'], '#c2d5d7')
+assert.ok(
+	getContrastRatio(values_solarized['text-color'], values_solarized['bg-color']) >= 7,
+	'Solarized Dark body text must meet WCAG AAA'
+)
+
+assert.match(
+	text_base,
+	/--search-match-bg:\s*color-mix\(in srgb, var\(--link-color\) 18%, transparent\);/
+)
+assert.match(
+	text_base,
+	/--search-match-current-bg:\s*color-mix\(in srgb, var\(--link-color\) 32%, transparent\);/
+)
+assert.match(text_base, /body:not\(\.theme-custom\), body\.theme-light\s*\{/)
+assert.doesNotMatch(text_base, /body, body\.theme-light\s*\{/)
+assert.match(text_base, /\.search-match\s*\{[^}]*background: var\(--search-match-bg\);/s)
+assert.match(
+	text_base,
+	/\.search-match-current\s*\{[^}]*background: var\(--search-match-current-bg\);/s
+)
+
+console.log('Theme color contract passed for 12 built-in and standalone themes.')

--- a/scripts/check-theme-colors.mjs
+++ b/scripts/check-theme-colors.mjs
@@ -45,6 +45,19 @@ function getVariables(text_block) {
 	return values_token
 }
 
+function getDefaultTheme() {
+	const match_theme = text_base.match(/:root,\s*body\.theme-light\s*\{([^}]+)\}/)
+	assert.ok(match_theme, 'Light defaults must provide the :root token baseline')
+	return getVariables(match_theme[1])
+}
+
+function getCustomTheme(text_theme) {
+	return {
+		...getDefaultTheme(),
+		...getVariables(text_theme)
+	}
+}
+
 function getBuiltInTheme(name_theme) {
 	const pattern_theme = new RegExp(
 		`body(?:,\\s*body)?\\.theme-${name_theme}\\s*\\{([^}]+)\\}`
@@ -155,12 +168,31 @@ assert.match(
 	text_base,
 	/--search-match-current-bg:\s*color-mix\(in srgb, var\(--link-color\) 32%, transparent\);/
 )
-assert.match(text_base, /body:not\(\.theme-custom\), body\.theme-light\s*\{/)
-assert.doesNotMatch(text_base, /body, body\.theme-light\s*\{/)
+assert.doesNotMatch(text_base, /body:not\(\.theme-custom\)/)
 assert.match(text_base, /\.search-match\s*\{[^}]*background: var\(--search-match-bg\);/s)
 assert.match(
 	text_base,
 	/\.search-match-current\s*\{[^}]*background: var\(--search-match-current-bg\);/s
 )
+
+const values_default = getDefaultTheme()
+const values_partial = getCustomTheme(`
+body {
+	--link-color: #0055aa;
+}
+`)
+assert.equal(values_partial['link-color'], '#0055aa')
+assert.equal(values_partial['bg-color'], values_default['bg-color'])
+assert.equal(values_partial['text-color'], values_default['text-color'])
+assert.equal(values_partial['border-color'], values_default['border-color'])
+
+const values_direct = getCustomTheme(`
+#editor .ProseMirror strong {
+	color: #c44b2b;
+}
+`)
+assert.equal(values_direct['bg-color'], values_default['bg-color'])
+assert.equal(values_direct['text-color'], values_default['text-color'])
+assert.equal(values_direct['border-color'], values_default['border-color'])
 
 console.log('Theme color contract passed for 12 built-in and standalone themes.')

--- a/src/renderer/themes/base.css
+++ b/src/renderer/themes/base.css
@@ -546,7 +546,7 @@ body.show-file-panel #source-editor {
 
 /* ======= THEMES ======= */
 
-body:not(.theme-custom), body.theme-light {
+:root, body.theme-light {
   --bg-color: #ffffff;
   --text-color: #24292f;
   --text-secondary: #656d76;

--- a/src/renderer/themes/base.css
+++ b/src/renderer/themes/base.css
@@ -12,6 +12,11 @@ html, body {
   color: var(--text-color);
 }
 
+body {
+  --search-match-bg: color-mix(in srgb, var(--link-color) 18%, transparent);
+  --search-match-current-bg: color-mix(in srgb, var(--link-color) 32%, transparent);
+}
+
 #titlebar {
   -webkit-app-region: drag;
   height: 52px;
@@ -216,7 +221,7 @@ html, body {
   font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: var(--text-muted);
+  color: var(--text-secondary, var(--text-muted));
   padding: 4px 8px 8px;
   user-select: none;
 }
@@ -288,7 +293,7 @@ html, body {
 }
 
 #file-list button.parent {
-  color: var(--text-muted);
+  color: var(--text-secondary, var(--text-muted));
   border-bottom: 1px solid var(--border-color);
   border-radius: 0;
   margin-bottom: 4px;
@@ -409,7 +414,7 @@ body.show-file-panel #source-editor {
   border: 1px solid var(--border-color);
   border-radius: 4px;
   background: var(--bg-color);
-  color: var(--text-muted);
+  color: var(--text-secondary, var(--text-muted));
   font: inherit;
   font-size: 12px;
   line-height: 1.4;
@@ -442,7 +447,7 @@ body.show-file-panel #source-editor {
   border-left: 4px solid var(--blockquote-border);
   padding-left: 16px;
   margin: 1em 0;
-  color: var(--text-muted);
+  color: var(--text-secondary, var(--text-muted));
 }
 
 /* Lists */
@@ -491,7 +496,7 @@ body.show-file-panel #source-editor {
 }
 
 #editor .ProseMirror li[data-item-type="task"][data-checked="true"] > p {
-  color: var(--text-muted);
+  color: var(--text-secondary, var(--text-muted));
   text-decoration: line-through;
 }
 
@@ -541,9 +546,10 @@ body.show-file-panel #source-editor {
 
 /* ======= THEMES ======= */
 
-body, body.theme-light {
+body:not(.theme-custom), body.theme-light {
   --bg-color: #ffffff;
   --text-color: #24292f;
+  --text-secondary: #656d76;
   --text-muted: #656d76;
   --border-color: #d0d7de;
   --link-color: #0969da;
@@ -558,6 +564,7 @@ body, body.theme-light {
 body.theme-dark {
   --bg-color: #0d1117;
   --text-color: #e6edf3;
+  --text-secondary: #aab3bd;
   --text-muted: #8b949e;
   --border-color: #30363d;
   --link-color: #58a6ff;
@@ -572,9 +579,10 @@ body.theme-dark {
 body.theme-elegant {
   --bg-color: #f0edea;
   --text-color: #2c2c2c;
+  --text-secondary: #6c6c6c;
   --text-muted: #777;
   --border-color: #d8d3ce;
-  --link-color: #c44b2b;
+  --link-color: #bc4424;
   --code-bg: #e8e4df;
   --code-block-bg: #2c2c2c;
   --code-block-text: #e0dcd7;
@@ -670,7 +678,7 @@ body.theme-elegant #editor .ProseMirror table td {
 
 .search-count {
   min-width: 32px;
-  color: var(--text-muted);
+  color: var(--text-secondary, var(--text-muted));
   font-size: 12px;
   text-align: center;
 }
@@ -695,12 +703,12 @@ body.theme-elegant #editor .ProseMirror table td {
 }
 
 .search-match {
-  background: rgba(255, 213, 79, 0.4);
+  background: var(--search-match-bg);
   border-radius: 2px;
 }
 
 .search-match-current {
-  background: rgba(255, 152, 0, 0.6);
+  background: var(--search-match-current-bg);
   border-radius: 2px;
 }
 
@@ -784,7 +792,7 @@ body.theme-elegant #editor .ProseMirror table td {
   display: flex;
   align-items: center;
   gap: 8px;
-  color: var(--text-muted);
+  color: var(--text-secondary, var(--text-muted));
   font-size: 13px;
 }
 

--- a/src/renderer/themes/premium.css
+++ b/src/renderer/themes/premium.css
@@ -10,9 +10,10 @@
 body.theme-sepia {
   --bg-color: #f6efe0;
   --text-color: #4f4032;
+  --text-secondary: #7b6b54;
   --text-muted: #9a8a72;
   --border-color: #e2d7bf;
-  --link-color: #a0622d;
+  --link-color: #9c5e29;
   --code-bg: rgba(122, 90, 51, 0.1);
   --code-block-bg: #ece2cb;
   --blockquote-border: #c9a86a;
@@ -52,6 +53,7 @@ body.theme-sepia #editor .ProseMirror code {
 body.theme-notion {
   --bg-color: #ffffff;
   --text-color: #37352f;
+  --text-secondary: #777674;
   --text-muted: #9b9a97;
   --border-color: #e9e9e7;
   --link-color: #37352f;
@@ -97,6 +99,7 @@ body.theme-notion #editor .ProseMirror table td {
 body.theme-bear {
   --bg-color: #ffffff;
   --text-color: #262626;
+  --text-secondary: #767676;
   --text-muted: #8a8a8a;
   --border-color: #e8e6e3;
   --link-color: #d43d2a;
@@ -132,6 +135,7 @@ body.theme-bear #editor .ProseMirror hr {
 body.theme-writer {
   --bg-color: #fcfcfa;
   --text-color: #1a1a1a;
+  --text-secondary: #757571;
   --text-muted: #8e8e8a;
   --border-color: #e3e3de;
   --link-color: #3b6ec4;
@@ -172,10 +176,11 @@ body.theme-writer #editor .ProseMirror table td {
    muted cyan text, stars of orange and blue. */
 body.theme-solarized-dark {
   --bg-color: #002b36;
-  --text-color: #839496;
+  --text-color: #c2d5d7;
+  --text-secondary: #a4bbc3;
   --text-muted: #586e75;
   --border-color: #0d3d4a;
-  --link-color: #268bd2;
+  --link-color: #3093da;
   --code-bg: rgba(88, 110, 117, 0.22);
   --code-block-bg: #073642;
   --blockquote-border: #2aa198;
@@ -205,6 +210,7 @@ body.theme-solarized-dark #editor .ProseMirror code {
 body.theme-nord {
   --bg-color: #2e3440;
   --text-color: #d8dee9;
+  --text-secondary: #aebdd4;
   --text-muted: #7d8ba1;
   --border-color: #3b4252;
   --link-color: #88c0d0;
@@ -240,6 +246,7 @@ body.theme-nord #editor .ProseMirror blockquote {
 body.theme-gruvbox {
   --bg-color: #282828;
   --text-color: #ebdbb2;
+  --text-secondary: #c5b5a5;
   --text-muted: #928374;
   --border-color: #3c3836;
   --link-color: #83a598;
@@ -279,6 +286,7 @@ body.theme-gruvbox #editor .ProseMirror hr {
 body.theme-dracula {
   --bg-color: #282a36;
   --text-color: #f8f8f2;
+  --text-secondary: #afb7db;
   --text-muted: #7f86a8;
   --border-color: #44475a;
   --link-color: #bd93f9;
@@ -314,6 +322,7 @@ body.theme-dracula #editor .ProseMirror blockquote {
 body.theme-midnight {
   --bg-color: #000000;
   --text-color: #d6d6d6;
+  --text-secondary: #b1b1b1;
   --text-muted: #7a7a7a;
   --border-color: #262626;
   --link-color: #0a84ff;

--- a/themes/README.md
+++ b/themes/README.md
@@ -68,5 +68,5 @@ For more control, target elements directly:
 ### Tips
 
 - Theme files should be self-contained (no external imports)
-- Test that all variables are defined to avoid invisible text
+- Omitted variables inherit ColaMD's Light defaults, so override only the tokens your theme needs
 - Name the file descriptively: `dark-ocean.css`, `solarized-light.css`, etc.

--- a/themes/README.md
+++ b/themes/README.md
@@ -36,6 +36,7 @@ ColaMD custom themes are plain CSS files. You can style the editor by targeting 
 body {
   --bg-color: #ffffff;
   --text-color: #24292f;
+  --text-secondary: #656d76;
   --text-muted: #656d76;
   --border-color: #d0d7de;
   --link-color: #0969da;
@@ -48,6 +49,11 @@ body {
   --selection-bg: rgba(0,0,0,0.1);
 }
 ```
+
+`--text-secondary` is for readable labels and secondary copy. `--text-muted`
+is reserved for subdued icons and disabled states. Search highlights derive
+from `--link-color` automatically and can be overridden with
+`--search-match-bg` and `--search-match-current-bg` when needed.
 
 ### Direct Selectors
 

--- a/themes/bear.css
+++ b/themes/bear.css
@@ -7,6 +7,7 @@
 :root {
   --bg-color: #ffffff;
   --text-color: #262626;
+  --text-secondary: #767676;
   --text-muted: #8a8a8a;
   --border-color: #e8e6e3;
   --link-color: #d43d2a;

--- a/themes/dark.css
+++ b/themes/dark.css
@@ -7,6 +7,7 @@
 :root {
   --bg-color: #0d1117;
   --text-color: #e6edf3;
+  --text-secondary: #aab3bd;
   --text-muted: #8b949e;
   --border-color: #30363d;
   --link-color: #58a6ff;

--- a/themes/dracula.css
+++ b/themes/dracula.css
@@ -7,6 +7,7 @@
 :root {
   --bg-color: #282a36;
   --text-color: #f8f8f2;
+  --text-secondary: #afb7db;
   --text-muted: #7f86a8;
   --border-color: #44475a;
   --link-color: #bd93f9;

--- a/themes/elegant.css
+++ b/themes/elegant.css
@@ -7,9 +7,10 @@
 :root {
   --bg-color: #f0edea;
   --text-color: #2c2c2c;
+  --text-secondary: #6c6c6c;
   --text-muted: #777;
   --border-color: #d8d3ce;
-  --link-color: #c44b2b;
+  --link-color: #bc4424;
   --code-bg: #e8e4df;
   --code-block-bg: #2c2c2c;
   --code-block-text: #e0dcd7;

--- a/themes/gruvbox.css
+++ b/themes/gruvbox.css
@@ -7,6 +7,7 @@
 :root {
   --bg-color: #282828;
   --text-color: #ebdbb2;
+  --text-secondary: #c5b5a5;
   --text-muted: #928374;
   --border-color: #3c3836;
   --link-color: #83a598;

--- a/themes/light.css
+++ b/themes/light.css
@@ -7,6 +7,7 @@
 :root {
   --bg-color: #ffffff;
   --text-color: #24292f;
+  --text-secondary: #656d76;
   --text-muted: #656d76;
   --border-color: #d0d7de;
   --link-color: #0969da;

--- a/themes/midnight.css
+++ b/themes/midnight.css
@@ -7,6 +7,7 @@
 :root {
   --bg-color: #000000;
   --text-color: #d6d6d6;
+  --text-secondary: #b1b1b1;
   --text-muted: #7a7a7a;
   --border-color: #262626;
   --link-color: #0a84ff;

--- a/themes/nord.css
+++ b/themes/nord.css
@@ -7,6 +7,7 @@
 :root {
   --bg-color: #2e3440;
   --text-color: #d8dee9;
+  --text-secondary: #aebdd4;
   --text-muted: #7d8ba1;
   --border-color: #3b4252;
   --link-color: #88c0d0;

--- a/themes/notion.css
+++ b/themes/notion.css
@@ -7,6 +7,7 @@
 :root {
   --bg-color: #ffffff;
   --text-color: #37352f;
+  --text-secondary: #777674;
   --text-muted: #9b9a97;
   --border-color: #e9e9e7;
   --link-color: #37352f;

--- a/themes/sepia.css
+++ b/themes/sepia.css
@@ -7,9 +7,10 @@
 :root {
   --bg-color: #f6efe0;
   --text-color: #4f4032;
+  --text-secondary: #7b6b54;
   --text-muted: #9a8a72;
   --border-color: #e2d7bf;
-  --link-color: #a0622d;
+  --link-color: #9c5e29;
   --code-bg: rgba(122, 90, 51, 0.1);
   --code-block-bg: #ece2cb;
   --blockquote-border: #c9a86a;

--- a/themes/solarized-dark.css
+++ b/themes/solarized-dark.css
@@ -6,10 +6,11 @@
 
 :root {
   --bg-color: #002b36;
-  --text-color: #839496;
+  --text-color: #c2d5d7;
+  --text-secondary: #a4bbc3;
   --text-muted: #586e75;
   --border-color: #0d3d4a;
-  --link-color: #268bd2;
+  --link-color: #3093da;
   --code-bg: rgba(88, 110, 117, 0.22);
   --code-block-bg: #073642;
   --blockquote-border: #2aa198;

--- a/themes/writer.css
+++ b/themes/writer.css
@@ -7,6 +7,7 @@
 :root {
   --bg-color: #fcfcfa;
   --text-color: #1a1a1a;
+  --text-secondary: #757571;
   --text-muted: #8e8e8a;
   --border-color: #e3e3de;
   --link-color: #3b6ec4;


### PR DESCRIPTION
## Summary

- introduce readable `--text-secondary` tokens for all 12 built-in and
  standalone themes while keeping `--text-muted` for subdued icons
- derive search match backgrounds from each theme's link color instead of
  using fixed yellow overlays
- improve Solarized Dark body contrast and adjust links in Elegant, Sepia,
  and Solarized Dark to meet WCAG AA
- let imported custom-theme variables override the default Light tokens

## Why

The previous search overlays became difficult to read on dark themes, while
`--text-muted` was shared by both decorative icons and small readable labels.
Solarized Dark body text also had insufficient APCA contrast, and three link
colors fell below WCAG AA.

## Validation

- `node scripts/check-theme-colors.mjs`
- `npm run build`
- `git diff --check origin/main...HEAD`
- visual checks in Light and Solarized Dark for search matches, editor text,
  and file-panel secondary text
