### PR TITLE
fix(editor): keep code block copy button anchored in-block and stop it vanishing on hover

### DIFF
--- a/src/renderer/editor/editor.ts
+++ b/src/renderer/editor/editor.ts
@@ -138,10 +138,14 @@ function editorRect(): DOMRect {
 
 function positionCopyButton(pre: HTMLPreElement): void {
   if (!copyButton) return
+  const editor = document.getElementById('editor') as HTMLElement
   const rect = pre.getBoundingClientRect()
   const base = editorRect()
-  copyButton.style.left = `${rect.left - base.left + rect.width - 8}px`
-  copyButton.style.top = `${rect.top - base.top + 8}px`
+  // The button is absolutely positioned inside the scroll container #editor, so
+  // its top/left are measured from the scroll-content origin, not from the
+  // editor's border box. Add the scroll offsets so it tracks the block.
+  copyButton.style.left = `${rect.left - base.left + editor.scrollLeft + rect.width - 8}px`
+  copyButton.style.top = `${rect.top - base.top + editor.scrollTop + 8}px`
 }
 
 function createCopyButton(): HTMLButtonElement {
@@ -179,34 +183,57 @@ function createCopyButton(): HTMLButtonElement {
 
 function setupCodeBlockCopy(root: HTMLElement): void {
   copyButton = createCopyButton()
+  const btn = copyButton
 
-  const sync = (event?: MouseEvent): void => {
-    if (!copyButton) return
-    const related = event?.relatedTarget
-    if (related === copyButton || related instanceof Node && copyButton.contains(related)) return
+  const inButton = (node: Node | null): boolean =>
+    !!node && (node === btn || btn.contains(node))
 
-    const pre = root.querySelector('pre:hover') as HTMLPreElement | null
-    if (pre && pre.querySelector('code')) {
-      copyButtonPre = pre
-      copyButton.classList.add('hovering')
-      positionCopyButton(pre)
-    } else if (copyButton.matches(':hover') && copyButtonPre) {
-      copyButton.classList.add('hovering')
-    } else {
-      copyButtonPre = null
-      copyButton.classList.remove('hovering')
-    }
+  const showFor = (pre: HTMLPreElement): void => {
+    copyButtonPre = pre
+    btn.classList.add('hovering')
+    positionCopyButton(pre)
   }
 
-  // ProseMirror fires DOM mutations on every doc change, so re-sync on its
-  // transaction loop instead of a MutationObserver (avoids self-trigger loops).
-  root.addEventListener('mouseover', sync)
-  root.addEventListener('mouseout', sync)
-  copyButton.addEventListener('mouseleave', sync)
-  window.addEventListener('scroll', () => sync(), { passive: true })
-  const resizeObserver = new ResizeObserver(() => sync())
+  const hide = (): void => {
+    copyButtonPre = null
+    btn.classList.remove('hovering')
+  }
+
+  const positionActive = (): void => {
+    if (copyButtonPre) positionCopyButton(copyButtonPre)
+  }
+
+  // Show the copy button when the pointer enters a fenced code block.
+  root.addEventListener('mouseover', (event) => {
+    if (inButton(event.target as Node)) return
+    const pre = (event.target as Element | null)?.closest?.('pre') as HTMLPreElement | null
+    if (pre && pre.querySelector('code')) showFor(pre)
+  })
+
+  // Keep the button visible until the pointer leaves BOTH the block and the
+  // button. The button is a sibling overlay sitting on top of the <pre>, so
+  // hovering it makes `pre:hover` false — we must not gate visibility on
+  // `:hover` or the button disappears mid-interaction (original bug).
+  root.addEventListener('mouseout', (event) => {
+    const from = (event.target as Element | null)?.closest?.('pre') as HTMLPreElement | null
+    if (!from || from !== copyButtonPre) return
+    const to = event.relatedTarget as Node | null
+    if (inButton(to)) return
+    if (to && from.contains(to)) return
+    hide()
+  })
+
+  btn.addEventListener('mouseout', (event) => {
+    const to = event.relatedTarget as Node | null
+    if (copyButtonPre && to && copyButtonPre.contains(to)) return
+    hide()
+  })
+
+  // #editor is the scroll container; reposition when the block moves.
+  root.addEventListener('scroll', positionActive, { passive: true })
+  window.addEventListener('scroll', positionActive, { passive: true })
+  const resizeObserver = new ResizeObserver(positionActive)
   resizeObserver.observe(root)
-  sync()
 }
 
 function toggleStrongMark(): void {

--- a/src/renderer/themes/base.css
+++ b/src/renderer/themes/base.css
@@ -185,6 +185,7 @@ body {
 }
 
 #editor {
+  position: relative; /* anchor for the absolutely-positioned code copy button */
   height: calc(100vh - 40px);
   overflow-y: auto;
   padding: 0 40px 40px;


### PR DESCRIPTION
## 问题

编辑器里代码块右上角的「复制」按钮有两个毛病：

1. **位置不固定、不在框内**：按钮是挂在 `#editor` 上的单个绝对定位浮层，但 `#editor` 没有 `position: relative`，按钮的定位基准其实是视口/body，而代码却用 `rect - base` 来计算坐标，导致整体偏出代码块（悬在块上方）；且编辑器滚动后按钮不跟随块（定位公式缺少 `scrollTop` 项）。
2. **鼠标移上去反而消失**：按钮是 `pre` 的兄弟节点、叠在 `pre` 上面，而显隐逻辑用 `pre:hover` 判定。光标一压到按钮上，`pre:hover` 立即变假，唯一保住的兜底分支只覆盖「光标正好在按钮上」那一瞬，中间态一律把按钮隐藏。

## 改动

- `src/renderer/themes/base.css`：给 `#editor` 加 `position: relative`，让绝对定位的按钮以编辑器为包含块。
- `src/renderer/editor/editor.ts`：
  - 重写 `setupCodeBlockCopy` 的 hover 追踪：用 `mouseover`/`mouseout` + `closest('pre')` 定位当前块，而不是依赖 `pre:hover`；
  - 拆分 `showFor` / `hide` / `positionActive`，只有在指针**同时离开块和按钮**时才隐藏，修掉「移入按钮就消失」；
  - 修正 `positionCopyButton`：`top/left` 基于滚动内容原点（补上 `editor.scrollTop`/`editor.scrollLeft`），让按钮在编辑器滚动时也跟随代码块。

保留了原有设计「按钮放在 ProseMirror 管理的 DOM 之外（`#editor` 下、`.ProseMirror` 的兄弟）」，避开 ProseMirror 重同步擦 DOM / 代码块无限重建循环的坑。

## 行为（维持原交互）

按钮默认隐藏，hover 到代码块时出现在块内右上角（离顶部 8px、右缘 8px），移入按钮不消失，离开块和按钮后隐藏。

## 验证

- `tsc` 渲染进程类型检查：无新增错误（仅剩改动前就存在的 `mermaid-sandbox.ts` 报错）。
- `electron-vite build`：通过。
- 在真实运行的 Electron 渲染进程里用 CDP 驱动验证：
  - 定位：`scrollTop=0/600/1200` 下按钮均在块内（`inBlock:true`、垂直偏移恒 `+8`），随滚动正确跟随。
  - hover：`afterOver:true`、`afterOverToBtn:true`（移入按钮不再消失）、`afterLeave:false`（离开两者才隐藏）。
  - 复制：点击后按钮变为「已复制 ✓」。


## 相关 Issue
- 关联 bug 报告： #53
