### PR TITLE
fix(updater): Windows 应用内更新 404（latest.yml 与发布资产名不一致）并补上失败提示

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -59,6 +59,12 @@ linux:
   icon: resources/icon.png
 
 nsis:
+  # No spaces: the default "${productName} Setup ${version}.exe" gets sanitized
+  # two different ways (latest.yml: space -> "-", GitHub asset: space -> "."),
+  # so the updater requested a filename that never existed on the release
+  # (ColaMD-Setup-2.0.0.exe vs ColaMD.Setup.2.0.0.exe) and every in-app update
+  # on Windows failed with a silent 404 (#56).
+  artifactName: ${productName}-Setup-${version}.${ext}
   oneClick: false
   allowToChangeInstallationDirectory: true
 

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -626,7 +626,15 @@ async function init(): Promise<void> {
     } else {
       updateBannerActionEl().textContent = '下载中…'
       updateBannerActionEl().disabled = true
-      await api.downloadUpdate()
+      try {
+        await api.downloadUpdate()
+      } catch (error) {
+        // 'update-downloaded' drives the success path; on failure the button
+        // must come back so the user can retry and see why it failed (#56).
+        updateBannerTextEl().textContent = `下载失败：${error instanceof Error ? error.message : String(error)}`
+        updateBannerActionEl().textContent = '更新'
+        updateBannerActionEl().disabled = false
+      }
     }
   })
   document.getElementById('update-banner-dismiss')!.addEventListener('click', () => {


### PR DESCRIPTION
## 问题

Windows 用户在应用内点「更新」后永远停在「下载中…」（#56）。根因是更新源元数据与实际发布的资产名不一致，**自 v1.9.0 起每个版本的 Windows 应用内更新都必然失败**：

- `latest.yml` 记录的是 `ColaMD-Setup-2.0.0.exe`（短横线）
- 实际发布的资产是 `ColaMD.Setup.2.0.0.exe`（点号）

实测：<https://github.com/marswaveai/ColaMD/releases/download/v2.0.0/ColaMD-Setup-2.0.0.exe> 返回 404，点号名返回 200。

## 根因

配置里没有显式 `artifactName`，NSIS 走 electron-builder 默认命名 `${productName} Setup ${version}.exe`（含空格）。这个名字随后被两边的净化规则各改各的：

1. **latest.yml 侧**（app-builder-lib `platformPackager.js → computeSafeArtifactNameIfNeeded`）：GitHub 文件名不允许空格 → 空格替换为 `-` → `ColaMD-Setup-2.0.0.exe`
2. **GitHub 资产侧**：上传后 GitHub 把资产名中的空格规范化为 `.` → `ColaMD.Setup.2.0.0.exe`

于是更新器永远请求一个不存在的文件名，`downloadUpdate()` reject。同时渲染进程的下载按钮没有 try/catch、主进程 `autoUpdater.on('error')` 只 `console.error`，失败对用户完全不可见。

## 修复

- `electron-builder.yml`：为 nsis 显式指定不含空格的 `artifactName: ${productName}-Setup-${version}.${ext}`。不含不安全字符时 `computeSafeArtifactNameIfNeeded` 直接返回原始名，latest.yml 与发布资产从此必然一致
- `src/renderer/main.ts`：下载失败时捕获 IPC 错误，恢复「更新」按钮可重试，并在横幅显示失败原因（#56 期望的「如果失败，应显示具体错误原因」）

## 给维护者的即时缓解建议（可选）

不改代码也能先止血：把 v2.0.0 release 的资产 `ColaMD.Setup.2.0.0.exe` 改名为 `ColaMD-Setup-2.0.0.exe`（GitHub 资产支持改名），现有 Windows 用户的应用内更新即可立即恢复，无需发新版本。

## 验证

- `tsc --noEmit`（main / preload / renderer）与 `npm run build` 通过
- 404/200 对照实测见上；electron-builder 26 源码中两套命名的产生路径已在本地 node_modules 中逐一核对

Fixes #56