### PR TITLE
fix(mermaid): 沙箱重建时拒绝积压渲染请求，并校验消息来源

### DIFF
--- a/src/renderer/editor/mermaid-bridge.ts
+++ b/src/renderer/editor/mermaid-bridge.ts
@@ -28,7 +28,9 @@ let iframe: HTMLIFrameElement | null = null
 let ready = false
 let nextRenderId = 0
 const pending = new Map<number, Pending>()
-const waitingForReady: Array<() => void> = []
+type QueuedRender = { run: () => void; reject: (reason: Error) => void }
+
+const waitingForReady: QueuedRender[] = []
 
 function currentTheme(): 'default' | 'dark' {
   for (const cls of DARK_THEME_CLASSES) {
@@ -66,7 +68,10 @@ function destroyIframe(): void {
     iframe = null
   }
   ready = false
-  waitingForReady.length = 0
+  // Queued requests never reached `pending`, so reject them here too or their
+  // promises never settle and the blocks hang on the source view forever.
+  const queued = waitingForReady.splice(0)
+  for (const entry of queued) entry.reject(new Error('渲染超时，已重置渲染器'))
 }
 
 function ensureIframe(): void {
@@ -104,7 +109,7 @@ window.addEventListener('message', (event) => {
   if (data.type === 'ready') {
     ready = true
     const queued = waitingForReady.splice(0)
-    for (const run of queued) run()
+    for (const entry of queued) entry.run()
     return
   }
 
@@ -124,7 +129,7 @@ export function renderMermaid(code: string): Promise<string> {
     if (ready) {
       dispatchRender(code, resolve, reject)
     } else {
-      waitingForReady.push(() => dispatchRender(code, resolve, reject))
+      waitingForReady.push({ run: () => dispatchRender(code, resolve, reject), reject })
     }
   })
 }

--- a/src/renderer/sandbox/mermaid-sandbox.ts
+++ b/src/renderer/sandbox/mermaid-sandbox.ts
@@ -20,6 +20,7 @@ const BASE_CONFIG = {
 mermaid.initialize({ ...BASE_CONFIG, theme: 'default' })
 
 window.addEventListener('message', (event) => {
+  if (event.source !== window.parent) return
   const data = event.data as RenderRequest | undefined
   if (!data || data.type !== 'render' || typeof data.id !== 'number' || typeof data.code !== 'string') return
 


### PR DESCRIPTION
## 问题 1：渲染超时后部分 Mermaid 块永远卡在源码态

任一渲染超时（15s）会 `destroyIframe()` 重建沙箱，但此时还在 `waitingForReady` 里等 iframe ready 的渲染请求被 `waitingForReady.length = 0` **直接丢弃且不 reject**——这些 Promise 永远不 settle，对应的代码块会一直停在源码视图、无任何错误提示，直到内容再次变化才恢复。

## 修复 1

`waitingForReady` 改为携带 `reject` 的队列项；`destroyIframe()` 清空队列时逐个 reject（「渲染超时，已重置渲染器」），节点视图得以走既有的错误展示路径。

## 问题 2：沙箱不校验消息来源

桥接侧已用 `event.source !== iframe.contentWindow` 校验来源，但沙箱侧（`mermaid-sandbox.ts`）的 message 监听**接受任何来源**的渲染请求。本应用场景风险不高，但双向校验才是完整闭环。

## 修复 2

沙箱监听开头加 `if (event.source !== window.parent) return`。

## 验证

- `tsc --noEmit`（main / preload / renderer）与 `npm run build` 通过
- 逻辑推演：超时 → rejectAllPending（在途请求）→ destroyIframe（拒绝积压请求）→ 下一次 renderMermaid 重建 iframe 并走 ready 队列，全链路所有 Promise 均可 settle