### PR TITLE
fix(security): stop interpolating appPath into shell strings in afterPack

### DIFF
--- a/scripts/afterPack.js
+++ b/scripts/afterPack.js
@@ -1,4 +1,4 @@
-const { execSync } = require('child_process')
+const { execFileSync } = require('child_process')
 const path = require('path')
 
 exports.default = async function (context) {
@@ -7,7 +7,11 @@ exports.default = async function (context) {
   const appPath = path.join(context.appOutDir, `${context.packager.appInfo.productFilename}.app`)
   console.log(`Cleaning extended attributes and resource forks from ${appPath}`)
   // Remove extended attributes
-  execSync(`xattr -cr "${appPath}"`)
+  execFileSync('xattr', ['-cr', appPath], { stdio: 'inherit' })
   // Remove HFS+ resource forks that xattr -cr doesn't handle
-  execSync(`find "${appPath}" -type f -exec sh -c 'cat /dev/null > "$1/..namedfork/rsrc" 2>/dev/null; true' _ {} \\;`)
+  execFileSync(
+    'find',
+    [appPath, '-type', 'f', '-exec', 'sh', '-c', 'cat /dev/null > "$1/..namedfork/rsrc" 2>/dev/null; true', '_', '{}', ';'],
+    { stdio: 'inherit' }
+  )
 }


### PR DESCRIPTION
## 解决的问题

`scripts/afterPack.js` 将打包路径 `appPath` 直接插值进 `execSync` 的 shell 字符串，构成命令注入面。

## 修复方式

`execSync` → `execFileSync`，以参数数组传递 `xattr` / `find` 的实参，打包路径不再经过任何 shell。行为完全不变（含 `find -exec sh -c` 内部通过 find 的 argv 传入文件路径的既有写法）。

独立的打包脚本修复，与功能 PR 无关，便于审计。
