### PR TITLE
feat(panel): resizable file panel width (180-420px, persisted)

### DIFF
--- a/docs/feature-requests.md
+++ b/docs/feature-requests.md
@@ -24,6 +24,12 @@ These features are implemented on `main` and await release verification.
 
 **Status:** Adds a Files / Outline switch in the existing sidebar. Headings navigate in both visual and Markdown source modes.
 
+### Resizable file panel
+
+**Sources:** [#64](https://github.com/marswaveai/ColaMD/issues/64)
+
+**Status:** The panel's right edge offers a lightweight drag hot zone (no permanent handle icon, hover stripe only, per design.md) to resize between 180px and 420px. The choice persists locally, the default stays 220px, and the hot zone hides with the panel.
+
 ### Windows startup performance
 
 **Sources:** [#32](https://github.com/marswaveai/ColaMD/issues/32)

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -63,6 +63,7 @@
     <ul id="file-list"></ul>
     <ul id="outline-list" hidden></ul>
   </aside>
+  <div id="panel-resizer" aria-hidden="true"></div>
   <div id="editor"></div>
   <textarea id="source-editor" spellcheck="false"></textarea>
   <div id="update-banner" hidden>

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -34,6 +34,23 @@ let manualHidden = localStorage.getItem('file-panel-hidden') !== '0'
 let panelMode: 'files' | 'outline' = 'files'
 let outlineUpdateQueued = false
 
+// Resizable file panel: default 220px, drag range 180-420px, persisted
+// locally (design.md). Applied at module load so the first paint already
+// uses the saved width.
+const FILE_PANEL_MIN_WIDTH = 180
+const FILE_PANEL_MAX_WIDTH = 420
+const FILE_PANEL_DEFAULT_WIDTH = 220
+
+function clampFilePanelWidth(width: number): number {
+  return Math.min(FILE_PANEL_MAX_WIDTH, Math.max(FILE_PANEL_MIN_WIDTH, Math.round(width)))
+}
+
+function applyFilePanelWidth(width: number): void {
+  document.documentElement.style.setProperty('--file-panel-width', `${width}px`)
+}
+
+applyFilePanelWidth(clampFilePanelWidth(Number.parseInt(localStorage.getItem('file-panel-width') ?? '', 10) || FILE_PANEL_DEFAULT_WIDTH))
+
 function setMarkdownProgrammatically(content: string): void {
   applyingProgrammaticChange = true
   try {
@@ -314,6 +331,36 @@ function togglePanel(): void {
   updatePanelVisibility()
 }
 
+// Drag the panel's right edge to resize it; the width clamps to the
+// design.md range and persists on release. Pointer capture keeps the drag
+// alive over iframes and selected text.
+function initPanelResize(): void {
+  const resizer = document.getElementById('panel-resizer') as HTMLDivElement | null
+  if (!resizer) return
+  resizer.addEventListener('pointerdown', (event) => {
+    event.preventDefault()
+    resizer.setPointerCapture(event.pointerId)
+    resizer.classList.add('dragging')
+    document.body.classList.add('panel-resizing')
+    let width = FILE_PANEL_DEFAULT_WIDTH
+    const move = (moveEvent: PointerEvent) => {
+      width = clampFilePanelWidth(moveEvent.clientX)
+      applyFilePanelWidth(width)
+    }
+    const finish = () => {
+      resizer.removeEventListener('pointermove', move)
+      resizer.removeEventListener('pointerup', finish)
+      resizer.removeEventListener('pointercancel', finish)
+      resizer.classList.remove('dragging')
+      document.body.classList.remove('panel-resizing')
+      localStorage.setItem('file-panel-width', String(width))
+    }
+    resizer.addEventListener('pointermove', move)
+    resizer.addEventListener('pointerup', finish)
+    resizer.addEventListener('pointercancel', finish)
+  })
+}
+
 function updateFileTitle(): void {
   const name = currentFilePath ? (currentFilePath.split(/[\\/]/).pop() || currentFilePath) : '未命名'
   fileTitleEl().textContent = name
@@ -501,6 +548,7 @@ async function init(): Promise<void> {
   })
 
   fileToggleBtnEl().addEventListener('click', togglePanel)
+  initPanelResize()
   fileTabEl().addEventListener('click', () => setPanelMode('files'))
   outlineTabEl().addEventListener('click', () => setPanelMode('outline'))
   api.onToggleFilePanel(() => togglePanel())

--- a/src/renderer/themes/base.css
+++ b/src/renderer/themes/base.css
@@ -243,7 +243,7 @@ body {
   top: 40px;
   left: 0;
   bottom: 0;
-  width: 220px;
+  width: var(--file-panel-width, 220px);
   z-index: 5;
   display: flex;
   flex-direction: column;
@@ -255,6 +255,34 @@ body {
 
 #file-panel[hidden] {
   display: none;
+}
+
+/* Edge hot zone for resizing the panel; deliberately handle-free — a hover
+   stripe is the only affordance (design.md). */
+#panel-resizer {
+  position: fixed;
+  top: 40px;
+  bottom: 0;
+  left: calc(var(--file-panel-width, 220px) - 3px);
+  width: 6px;
+  cursor: col-resize;
+  z-index: 6;
+  background: transparent;
+  transition: background 0.15s;
+}
+
+body:not(.show-file-panel) #panel-resizer {
+  display: none;
+}
+
+#panel-resizer:hover,
+#panel-resizer.dragging {
+  background: color-mix(in srgb, var(--link-color) 30%, transparent);
+}
+
+body.panel-resizing {
+  cursor: col-resize;
+  user-select: none;
 }
 
 .file-panel-tabs {
@@ -409,7 +437,7 @@ body {
 
 body.show-file-panel #editor,
 body.show-file-panel #source-editor {
-  margin-left: 220px;
+  margin-left: var(--file-panel-width, 220px);
 }
 
 #editor.hidden {


### PR DESCRIPTION
## 解决的问题

实现 design.md 刚刚接受的「可调文件面板」规格，并彻底解决 issue #64 中「宽度不能拖动，长标题显示不全」的宽度部分（tooltip 缓解部分在 #68）。

> Resizable file panel 已从 feature-requests.md 的 Declined 移入 design.md（180–420px 拖拽并持久化），本 PR 按该规格实现。

## 改动内容

- **拖拽热区**：面板右缘 6px 固定定位热区，`cursor: col-resize`；按 design.md 要求不显示常驻把手图标，仅 hover / 拖拽中显示主题色细条反馈（`color-mix(var(--link-color))` 派生，随主题适配）。
- **范围钳制**：拖拽宽度实时钳制在 `180px–420px`，默认仍为 `220px`。
- **持久化**：释放鼠标时写入 `localStorage('file-panel-width')`，模块加载时先应用再渲染，首帧即为保存的宽度、无闪跳。
- **联动细节**：
  - 编辑区 / 源码区 `margin-left` 与面板宽度共用同一 CSS 变量 `--file-panel-width`，拖拽时正文实时让位，不会出现面板遮挡正文；
  - 面板隐藏（⌘⇧B）时热区随之隐藏；
  - 使用 Pointer Capture，拖拽越过 iframe（Mermaid）和选中文本时不会中断。

## 实现说明

宽度全部走 CSS 变量：`#file-panel` 的 `width` 与 `body.show-file-panel #editor/#source-editor` 的 `margin-left` 引用同一 `--file-panel-width`，两处永远同步（初版曾漏改 margin 一处导致遮挡，已在实测中修复并回归）。

## 验证

- `tsc --noEmit`、`electron-vite build`、`check:theme-colors`（12 主题）通过。
- 实测（CDP + 真实拖拽）：拖拽时面板与正文同步移动；拖到两端分别钳制在 180/420 并正确持久化；重载后宽度保留；面板显隐联动热区显隐。
