### PR TITLE
fix: prevent source editor overflow when file panel is open

### DIFF
--- a/src/renderer/themes/base.css
+++ b/src/renderer/themes/base.css
@@ -474,6 +474,12 @@ body.show-file-panel #source-editor {
   margin-left: var(--file-panel-width, 220px);
 }
 
+/* The source editor has an explicit width, so account for the panel margin
+   instead of extending past the viewport when both are visible. */
+body.show-file-panel #source-editor {
+  width: calc(100% - var(--file-panel-width, 220px));
+}
+
 #editor.hidden {
   display: none;
 }


### PR DESCRIPTION
## Summary

Fix the horizontal overflow that occurs when Markdown source mode and the file panel are enabled at the same time.

<img width="1576" height="1440" alt="image" src="https://github.com/user-attachments/assets/b8a7baf6-9675-4fe8-a799-96ba77868f29" />


## Root Cause

The source editor used `width: 100%` while also receiving a left margin equal to the file panel width. This made its total width exceed the viewport.

## Changes

- Subtract the file panel width from the source editor width when the panel is visible.
- Preserve the existing layout for preview mode and source mode without the panel.

## Verification

- `npm run build`
- `npm run check:theme-colors`
- `git diff --check`
- Verified the source editor remains within the viewport with the file panel enabled.