### PR TITLE
fix(pdf): exclude app overlays and preserve screen layout during export

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -832,11 +832,16 @@ ipcMain.handle('export-pdf', async (event) => {
   try {
     const background = await win.webContents.executeJavaScript('getComputedStyle(document.body).backgroundColor') as string
     const cssKey = await win.webContents.insertCSS(
-      `@page { margin: 0; } html, body, #editor { height: auto !important; overflow: visible !important; background: ${background} !important; } #titlebar, #file-panel, #source-editor, #update-banner, .search-panel { display: none !important; } #editor { margin-left: 0 !important; padding: 20mm !important; } #editor .ProseMirror { min-height: auto !important; }`
+      `@media print {
+        @page { margin: 0; }
+        html, body, #editor { height: auto !important; overflow: visible !important; background: ${background} !important; }
+        #editor { margin-left: 0 !important; padding: 20mm !important; }
+        #editor .ProseMirror { min-height: auto !important; }
+      }`
     )
     try {
       const pdfData = await win.webContents.printToPDF({
-        margins: { marginType: 'none' },
+        margins: { top: 0, bottom: 0, left: 0, right: 0 },
         printBackground: true,
         pageSize: 'A4'
       })

--- a/src/renderer/themes/base.css
+++ b/src/renderer/themes/base.css
@@ -1237,3 +1237,11 @@ body.has-custom-font #source-editor {
   display: flex;
   gap: 10px;
 }
+
+/* Print only document content; app overlays can appear at any time. */
+@media print {
+  body > :not(#editor),
+  #editor > .code-copy-btn {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
Related to #71

  本 PR 在上游已有修复基础上，补齐 PDF 导出问题：
  - 排除弹窗、侧栏拖拽条和代码复制按钮。
  - 将导出布局样式限定在打印模式，保持编辑界面稳定。