### PR TITLE
chore: slim electron packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,13 +7,14 @@ on:
   workflow_dispatch:
     inputs:
       mac_arch:
-        description: 'macOS architecture to build'
+        description: 'macOS architecture (separate = one installer per architecture)'
         type: choice
         options:
+          - separate
           - universal
           - x64
           - arm64
-        default: universal
+        default: separate
 
 jobs:
   build:
@@ -50,11 +51,12 @@ jobs:
         run: |
           ARCH_ARGS=""
           if [ "${{ matrix.platform }}" = "mac" ]; then
-            case "${{ inputs.mac_arch || 'universal' }}" in
+            case "${{ inputs.mac_arch || 'separate' }}" in
+              separate) ARCH_ARGS="" ;;
               x64) ARCH_ARGS="--x64" ;;
               arm64) ARCH_ARGS="--arm64" ;;
               universal) ARCH_ARGS="--universal" ;;
-              *) ARCH_ARGS="--universal" ;;
+              *) ARCH_ARGS="" ;;
             esac
           fi
           npx electron-builder --${{ matrix.platform }} $ARCH_ARGS --publish never

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -8,6 +8,23 @@ directories:
 
 files:
   - dist/**/*
+  # All runtime JavaScript is bundled by electron-vite. Do not let
+  # electron-builder copy the complete production dependency tree into app.asar.
+  - '!node_modules/**/*'
+
+asar:
+  # The packaged app has no native modules. Avoid builder's broad automatic
+  # unpacking heuristics and keep the archive self-contained.
+  smartUnpack: false
+
+# ColaMD provides its own Chinese/English UI and only needs these Chromium
+# locale resources. Keeping every Electron locale adds tens of megabytes.
+# Electron uses hyphens on Linux and underscores in macOS .lproj names.
+electronLanguages:
+  - en-US
+  - en_US
+  - zh-CN
+  - zh_CN
 
 extraResources:
   - from: resources/templates
@@ -35,9 +52,20 @@ fileAssociations:
     mimeType: text/plain
 
 mac:
+  compression: maximum
+  # Publish separate installers for each CPU architecture instead of a
+  # universal binary. This keeps both Intel and Apple Silicon support while
+  # avoiding the duplicated Electron framework in every download.
+  artifactName: '${productName}-${version}-${arch}.${ext}'
   target:
-    - dmg
-    - zip
+    - target: dmg
+      arch:
+        - arm64
+        - x64
+    - target: zip
+      arch:
+        - arm64
+        - x64
   category: public.app-category.productivity
   icon: resources/icon.icns
   hardenedRuntime: true


### PR DESCRIPTION
## Summary

- Exclude bundled `node_modules` from the packaged app.
- Disable unnecessary ASAR smart unpacking.
- Keep only English and Chinese Electron locale resources.
- Build separate macOS arm64 and x64 artifacts by default.
- Keep universal, x64, and arm64 builds available for manual workflows.
- Enable maximum macOS compression and architecture-specific artifact names.

## Results

- macOS x64 app bundle: approximately 402 MB → 210 MB.
- `app.asar`: approximately 169 MB → 10.7 MB.
- Linux unpacked package: approximately 425 MB → 233 MB.
- Confirmed packaged output contains no `node_modules`.

## Validation

- `npm run build`
- TypeScript checks for main, preload, and renderer
- Theme color contract check
- YAML validation
- Linux electron-builder packaging
- macOS x64 and arm64 unpacked packaging

## Notes

The exact DMG size should be verified on macOS CI. The Linux orb cannot complete DMG generation because macOS `sips` is unavailable. Electron/Chromium itself remains the main size cost.