### PR TITLE
fix(reveal): restore the reveal-in-folder button wiring (#83)

### DIFF
--- a/design.md
+++ b/design.md
@@ -129,7 +129,8 @@ ColaMD 是轻量 Markdown 编辑器，不追求功能堆叠。每增加一个按
 - hover 说明不能遮挡主要内容，也不能阻止鼠标操作。
 - disabled 控件必须降低透明度并停止 hover 强调。
 - **标题栏是窗口拖拽区（`-webkit-app-region: drag`），其中的元素不会派发鼠标事件**：点击、mouseenter、hover 都不会触发。控件必须自己标 `-webkit-app-region: no-drag` 才能被点击。
-- **不要在标题栏内依赖 hover 显隐控件**：v2.0.5 试过把 hover 触发点下移到文件名（`no-drag` + `pointer-events: auto`），浏览器复现页里成立，但 2.0.5 真机上按钮始终不出现。机制细节未最终定位，结论已经明确：拖拽区内的 hover 不可靠，需要悬停才出现的控件不要放在标题栏，标题栏里的操作做成常驻按钮。
+- **标题栏内可以依赖 hover 显隐控件，但触发点必须自身可接收指针事件**：把 hover 触发点放在文件名（`no-drag` + `pointer-events: auto`）上，标题栏内的 hover 显隐是可靠的，`#titlebar:hover` 也会随之命中。v2.0.5 的「打开所在文件夹」按钮一度被认为 hover 失效，实际原因是提交 8dc5097 重构 `main.ts` 时删掉了该按钮的全部渲染层接线（元素引用、状态、`updateFileRevealButton()` 与点击绑定），按钮停在 `disabled`，而显隐规则是 `#titlebar:hover #reveal-file-btn:not(:disabled)`，禁用态永远不满足，因此永远不可见。接线恢复后 hover 与点击均正常。
+- **禁用态不要当作显隐门**：需要 hover 才出现的控件，不要再把它同时设成 `disabled` 又用 `:not(:disabled)` 显隐，否则一处遗漏就会表现为「hover 失灵」，排查成本高。
 - 文件切换、覆盖或丢失未保存内容前，必须给出明确确认。
 - 外部 Agent 修改文件时，使用已有的状态点和刷新机制，不新增常驻提示条。
 - 导出功能统一放在 File 菜单中；当前支持 PDF 和 HTML。

--- a/docs/feature-requests.md
+++ b/docs/feature-requests.md
@@ -92,11 +92,9 @@ These features are implemented on `main` and await release verification.
 
 **Target:** v2.0.6
 
-The reveal button shipped in v2.0.4 and v2.0.5 is gated on hovering the file name, and that gate never opens on a real build: the titlebar is a window drag region, and moving the hover target onto the file name (`no-drag` + `pointer-events: auto`) worked in a browser harness but not in 2.0.5 on macOS. The button is therefore in the titlebar markup but unreachable.
+The reveal button shipped in v2.0.4 and v2.0.5 was unreachable, but not because hover in the titlebar is unreliable. Commit `8dc5097` (stop undo from crossing documents) refactored `main.ts` and deleted every renderer hookup for the button: the element accessor, the `fileManagerName` state, `fileLocationLabel()`, `updateFileRevealButton()` and the click binding. `index.html` kept its hardcoded `disabled`. The visibility rule is `#titlebar:hover #reveal-file-btn:not(:disabled)`, so a permanently disabled button can never match and stayed at `opacity: 0`, which presents as a broken hover. `#titlebar:hover` in fact matches normally once the hover target on the file name is interactive.
 
-Decision: drop the hover reveal and let the button always show as the fourth icon in the titlebar row (document stats, source mode, file panel, reveal in folder).
-
-The v2.0.5 changelog line that describes the hover behaviour is inaccurate for the shipped build; the v2.0.6 entry should carry the correction.
+With the wiring restored the button appears on hovering the file name and the click reaches the main process, so the hover reveal works as designed. Making it a constant button remains a reasonable discoverability preference, but it is not required for correctness and the two changes should be decided separately.
 
 ## Security Maintenance
 

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -29,7 +29,7 @@
   <div id="titlebar">
     <div id="title-center">
       <span id="file-title">未命名</span>
-      <button id="reveal-file-btn" type="button" disabled title="打开所在文件夹" aria-label="打开所在文件夹">
+      <button id="reveal-file-btn" type="button" disabled aria-label="打开所在文件夹">
         <svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round" stroke-linejoin="round">
           <path d="M4 9.33 5 7.4a1.33 1.33 0 0 1 1.16-.73h7.33a1.33 1.33 0 0 1 1.29 1.67l-1.03 4a1.33 1.33 0 0 1-1.3 1H2.67a1.33 1.33 0 0 1-1.33-1.33V3.33A1.33 1.33 0 0 1 2.67 2h2.6a1.33 1.33 0 0 1 1.13.6l.54.8a1.33 1.33 0 0 0 1.11.6H12a1.33 1.33 0 0 1 1.33 1.33v1.33"/>
         </svg>

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -16,6 +16,7 @@ const fileTabEl = () => document.getElementById('file-panel-files') as HTMLButto
 const outlineTabEl = () => document.getElementById('file-panel-outline') as HTMLButtonElement
 const fileToggleBtnEl = () => document.getElementById('file-toggle-btn') as HTMLButtonElement
 const sourceToggleBtnEl = () => document.getElementById('source-toggle-btn') as HTMLButtonElement
+const revealFileBtnEl = () => document.getElementById('reveal-file-btn') as HTMLButtonElement
 const wordCountEl = () => document.getElementById('word-count') as HTMLElement
 const fileTitleEl = () => document.getElementById('file-title') as HTMLElement
 const saveStatusEl = () => document.getElementById('save-status') as HTMLElement
@@ -25,6 +26,7 @@ const updateBannerActionEl = () => document.getElementById('update-banner-action
 
 // --- Same-directory file panel ---
 let currentFilePath: string | null = null
+let fileManagerName: import('../preload/index').FileManagerName = 'file-manager'
 let dirty = false
 // Programmatic Markdown replacement dispatches a synchronous ProseMirror
 // transaction. Suppress only that transaction, never a time window of input.
@@ -189,6 +191,7 @@ async function saveCurrent(saveAs = false): Promise<boolean> {
 
   currentFilePath = path
   updateFileTitle()
+  updateFileRevealButton()
   refreshSiblings()
   if (revision === documentRevision) {
     clearDirty()
@@ -229,6 +232,36 @@ function updateWordCount(content?: string): void {
     : `${countCharacters(text)} chars · ${countTokens(text)} words · ${countParagraphs(text)} paragraphs`
 }
 
+// --- Reveal the current file in the OS file manager ---
+function fileLocationLabel(): string {
+  if (isChinese()) {
+    return fileManagerName === 'finder'
+      ? '在 Finder 中显示'
+      : fileManagerName === 'explorer'
+        ? '在资源管理器中显示'
+        : '打开所在文件夹'
+  }
+  return fileManagerName === 'finder'
+    ? 'Reveal in Finder'
+    : fileManagerName === 'explorer'
+      ? 'Reveal in File Explorer'
+      : 'Open Containing Folder'
+}
+
+// The titlebar is a window drag region, so the button cannot rely on
+// `#titlebar:hover`. Its gate lives on the file title instead; this keeps the
+// label and the disabled state in sync with the loaded document.
+function updateFileRevealButton(): void {
+  const btn = revealFileBtnEl()
+  const label = fileLocationLabel()
+  btn.disabled = currentFilePath === null
+  // Only the styled .toolbar-tip is used; a native title tooltip would stack a
+  // second label on top of it. Sibling titlebar buttons rely on aria-label too.
+  btn.setAttribute('aria-label', label)
+  const tip = btn.querySelector('.toolbar-tip')
+  if (tip) tip.textContent = label
+}
+
 // --- Markdown source / WYSIWYG toggle ---
 function updateSourceToggle(): void {
   const btn = sourceToggleBtnEl()
@@ -251,6 +284,7 @@ function updateUiLanguage(): void {
   outlineTabEl().textContent = zh ? '大纲' : 'Outline'
   fileToggleBtnEl().setAttribute('aria-label', zh ? '显示 / 隐藏文件列表' : 'Show / hide file list')
   sourceToggleBtnEl().setAttribute('aria-label', zh ? '切换 Markdown 源码 / 所见即所得' : 'Toggle Markdown source / WYSIWYG')
+  updateFileRevealButton()
   const wordTip = wordCountEl().querySelector('.word-count-tip')
   if (wordTip) wordTip.textContent = zh ? '0 字 · 0 词 · 0 段' : '0 chars · 0 words · 0 paragraphs'
   updateSourceToggle()
@@ -712,6 +746,7 @@ async function exportCurrentImage(preset: 'desktop' | 'mobile'): Promise<void> {
 async function init(): Promise<void> {
   const api = window.electronAPI
   const language = await api.getLanguage()
+  fileManagerName = await api.getFileManagerName()
   setUiLanguage(language)
   const savedTheme = loadSavedTheme()
   if (savedTheme.startsWith('custom:')) {
@@ -756,6 +791,7 @@ async function init(): Promise<void> {
   })
 
   fileToggleBtnEl().addEventListener('click', togglePanel)
+  revealFileBtnEl().addEventListener('click', () => { void api.revealFile() })
   initPanelResize()
   fileTabEl().addEventListener('click', () => setPanelMode('files'))
   outlineTabEl().addEventListener('click', () => setPanelMode('outline'))
@@ -801,6 +837,7 @@ async function init(): Promise<void> {
   api.onFileOpened((data) => {
     releaseMermaidRenderer()
     currentFilePath = data.path
+    updateFileRevealButton()
     resetDirty()
     setContent(data.content, true)
     const resetScroll = () => {


### PR DESCRIPTION
## Problem

The **Reveal in folder** button (#77) is unreachable in v2.0.4 and v2.0.5. It is in the titlebar markup but permanently disabled, so it stays invisible and unclickable.

## Root cause

Commit `8dc5097` ("fix: stop undo from crossing documents") refactored `src/renderer/main.ts` for the undo fix and, in the same commit, deleted every renderer hookup for the reveal button:

- `revealFileBtnEl` element accessor
- `fileManagerName` state and its init call
- `fileLocationLabel()` and `updateFileRevealButton()`
- the click binding `revealFileBtnEl().addEventListener('click', () => api.revealFile())`
- the three `updateFileRevealButton()` calls in `saveCurrent`, `updateUiLanguage`, `onFileOpened`

`index.html` kept the button's hardcoded `disabled`, and nothing set `btn.disabled = false` again. The visibility rule is:

```css
#titlebar:hover #reveal-file-btn:not(:disabled) { opacity: 1; pointer-events: auto; }
```

A permanently disabled button never satisfies `:not(:disabled)`, so it is never shown. The main-process handler and preload bridge were untouched and work.

## Fix

Restores the deleted wiring (37 lines in `src/renderer/main.ts`). The hover reveal works as designed, so no change to the interaction model is required. Also removes the native `title` attribute, which was stacking a second OS tooltip on top of the app's own `.toolbar-tip`.

No main-process or preload changes.

## Verification

Type checks (main / preload / renderer), `npm run build`, and `check:theme-colors` all pass. Verified in a running Electron build with a document loaded:

- hovering the file name reveals the button
- a dispatched click lands on the button
- a debugger breakpoint inside the restored click handler is hit by that click
- `window.electronAPI.revealFile()` returns `true`
- screenshots of the revealed button posted on the issue

## Note on the v2.0.6 plan

`design.md` and `docs/feature-requests.md` currently attribute the failure to the titlebar being a drag region and schedule a constant button for v2.0.6. This PR corrects that record: the cause is the wiring regression. Making the button a constant icon is still a fine discoverability choice, but it is not needed for correctness and can be decided on its own merits.

Closes #83
